### PR TITLE
Plugins updates and fzf + ag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-vim/.netrwhist
-vim/.VimballRecord
-vim/backup
-vim/undo
-vim/autoload/plug.vim
-vim/plugins/*
+tags
+/vim/.netrwhist
+/vim/.VimballRecord
+/vim/autoload/*
+/vim/backup/*
+/vim/plugins/*
+/vim/undo/*
 !vim/plugins/cheat_sheet/
 !vim/plugins/cheat_sheet/doc/
 !vim/plugins/cheat_sheet/doc/cheat.txt

--- a/vim/keymaps_etc.vim
+++ b/vim/keymaps_etc.vim
@@ -136,33 +136,52 @@ nnoremap <leader>S :%s/\<<C-r><C-w>\>//g<Left><Left>
 " Ack ignores are stored in ~/.ackrc
 nmap <leader>f :Ag!<space>
 nmap <leader>F :Ag!<CR>
-nmap <leader>a :Ack!<space>
-nmap <leader>A :Ack!<CR>
+nmap <leader>a :FzfAg!<space>
+nmap <leader>A :FzfAg! <C-R><C-W><CR>
 
 " =============
 " FZF/CommandT/CtrlP
 " =============
-nmap <silent> <leader>t :GFiles<CR>
-" nmap <silent> <leader>T :CommandTFlush<CR>\|:CommandT<CR>
-nmap <silent> <leader>b :Buffers<CR>
+nmap <silent> <leader>t :FzfFiles<CR>
+nmap <silent> <leader>b :FzfBuffers<CR>
 nmap <silent> <leader>B :BufOnly<CR>
 " FZF mappings that work in Rails and Node.js projects:
 "   Idea from: https://github.com/skwp/dotfiles/blob/master/vim/settings/ctrlp.vim
 "   mnemonic 'jump to [something]'
-" models
+"   mnemonic 'ag/find/grep in [something]'
+"
+" 'models' dir e.g. app/models app/mixin/models src/models
 nmap <leader>jm :<c-u>call fzf#vim#files('', {'options': ['--query', "'/models/ "], 'source': 'fd --type f --exclude test --exclude public' })<cr>
-" views
+command! -bang -nargs=* AgToFzfModels call fzf#vim#ag(<q-args>, '--file-search-regex models --ignore test --ignore public', <bang>0)
+nmap <leader>am :AgToFzfModels<space>
+" 'views' dir e.g. app/views src/views
 nmap <leader>jv :<c-u>call fzf#vim#files('', {'options': ['--query', "'/views/ "], 'source': 'fd --type f --exclude test --exclude public' })<cr>
-" controllers
+command! -bang -nargs=* AgToFzfViews call fzf#vim#ag(<q-args>, '--file-search-regex views --ignore test --ignore public', <bang>0)
+nmap <leader>av :AgToFzfViews<space>
+" 'controllers' dir e.g. app/controllers app/mixin/controllers src/controllers
 nmap <leader>jc :<c-u>call fzf#vim#files('', {'options': ['--query', "'/controllers/ "], 'source': 'fd --type f --exclude test --exclude public' })<cr>
-" lib
-nmap <leader>jl :<c-u>call fzf#vim#files('', {'options': ['--query', "^lib \\| ^src/lib "], 'source': 'fd --type f --exclude test --exclude /public' })<cr>
-" db
+command! -bang -nargs=* AgToFzfControllers call fzf#vim#ag(<q-args>, '--file-search-regex controllers --ignore test --ignore public', <bang>0)
+nmap <leader>ac :AgToFzfControllers<space>
+" 'lib' dir e.g. lib src/lib
+nmap <leader>jl :<c-u>call fzf#vim#files('', {'options': ['--query', "^lib \\| ^src/lib "], 'source': 'fd --type f --exclude test --exclude public' })<cr>
+command! -bang -nargs=* AgToFzfLib call fzf#vim#ag(<q-args>, '--file-search-regex lib --ignore test --ignore public', <bang>0)
+nmap <leader>al :AgToFzfLib<space>
+" db/
 nmap <leader>jd :<c-u>call fzf#vim#files('', {'source': 'fd --type f --search-path db'})<cr>
-" tests
+command! -bang -nargs=* AgToFzfDb call fzf#vim#ag_raw(<q-args> . ' db/', <bang>0)
+nmap <leader>ad :AgToFzfDb<space>
+" tests/
 nmap <leader>jt :<c-u>call fzf#vim#files('', {'source': 'fd --type f --search-path test --exclude fixtures --exclude cassettes'})<cr>
-" config
+command! -bang -nargs=* AgToFzfTest call fzf#vim#ag_raw(<q-args> . ' test/', <bang>0)
+nmap <leader>at :AgToFzfTest<space>
+" specs/
+nmap <leader>js :<c-u>call fzf#vim#files('', {'source': 'fd --type f --search-path specs --exclude fixtures --exclude cassettes'})<cr>
+command! -bang -nargs=* AgToFzfSpec call fzf#vim#ag_raw(<q-args> . ' spec/', <bang>0)
+nmap <leader>as :AgToFzfSpec<space>
+" config/
 nmap <leader>jC :<c-u>call fzf#vim#files('', {'source': 'fd --type f --search-path config'})<cr>
+command! -bang -nargs=* AgToFzfConfig call fzf#vim#ag_raw(<q-args> . ' config/', <bang>0)
+nmap <leader>aC :AgToFzfConfig<space>
 " nmap <leader>ja :CommandT app/assets<CR>
 " nmap <leader>jh :CommandT app/helpers<CR>
 " nmap <leader>jF :CommandT test/fixtures<CR>
@@ -172,9 +191,9 @@ nmap <leader>jC :<c-u>call fzf#vim#files('', {'source': 'fd --type f --search-pa
 " nmap <leader>jF :CommandT spec/factories<CR>
 " nmap <leader>jV :CommandT vendor<CR>
 "Cmd-(m)ethod - jump to a method (tag in current file)
-nmap <leader>m :CtrlPBufTag<CR>
+nmap <leader>m :FzfBTags<CR>
 "Ctrl-(M)ethod - jump to a method (tag within a generated central tags file)
-nmap <leader>M :CtrlPTag<CR>
+nmap <leader>M :FzfTags<CR>
 
 
 " ======================================================================

--- a/vim/keymaps_etc.vim
+++ b/vim/keymaps_etc.vim
@@ -212,12 +212,12 @@ command! -range Dg <line1>,<line2>diffget | diffupdate
 command! -range Dp <line1>,<line2>diffput | diffupdate
 xmap <leader>dg :diffget<CR>\|:diffupdate<CR>
 xmap <leader>dp :diffput<CR>\|:diffupdate<CR>
-nmap <leader>gb :Gblame<CR>
-nmap <leader>gh :Gbrowse<CR>
-nmap <leader>gc :Gcommit<CR>
-nmap <leader>gd :Gvdiff<CR>
+nmap <leader>gb :Git blame<CR>
+nmap <leader>gh :GBrowse<CR>
+nmap <leader>gc :Git commit<CR>
+nmap <leader>gd :Gvdiffsplit<CR>
 nmap <leader>gr :Gread<CR>
-nmap <leader>gs :Gstatus<CR>
+nmap <leader>gs :Git<CR>
 nmap <leader>gw :Gwrite<CR>
 nmap <leader>gv :Gitv! --all<CR> " File mode
 vmap <leader>gv :Gitv! --all<CR> " File mode
@@ -318,27 +318,6 @@ nmap <C-p> <Plug>yankstack_substitute_older_paste
 nmap <C-n> <Plug>yankstack_substitute_newer_paste
 
 
-" ======================================================================
-"
-"                 Below Lies Functions and Autocmds...
-"
-"
-"                                             ,,,
-"                          _         _      \(((.
-"                   __,,../v\,----../ `-..=.>"" _\,_
-"          _______;/____<_  \_______\ \___////______;______
-"                ,"/      `.)        `.)       ```
-"               /,"        /7__       /7_
-"              ((          ' \\\       )))
-"               \\
-"                ))
-"               ((
-"                )
-"               /
-"
-"
-"
-"
 " ======================================================================
 " Functions
 " ======================================================================

--- a/vim/keymaps_etc.vim
+++ b/vim/keymaps_etc.vim
@@ -35,6 +35,9 @@ nmap Y y$
 " Close HTML tag (ctrl-/)
 imap <silent> <C-_> </<C-X><C-O>
 
+" auto-indent entire file
+nmap <leader>i gg=G<C-o><C-o>
+
 " Toggle paste mode
 "set pastetoggle=<F12>
 

--- a/vim/plugin_config.vim
+++ b/vim/plugin_config.vim
@@ -64,14 +64,31 @@ let g:solarized_hitrail=1          "default value is 0
 let g:lightline = {
   \ 'colorscheme': 'solarized',
   \ 'component_function': {
+  \   'mode': 'LightlineMode',
   \   'filename': 'LightlineFilename',
+  \   'modified': 'LightlineModified',
+  \   'readonly': 'LightlineReadonly',
   \   'fileformat': 'LightlineFileformat',
   \   'fileencoding': 'LightlineFileencoding',
+  \   'filetype': 'LightlineFiletype',
   \ },
   \ }
 
+function! LightlineMode()
+  return &filetype !=# 'nerdtree' ? lightline#mode() : ''
+endfunction
+
 function! LightlineFilename()
-  return winwidth(0) > 70 ? fnamemodify(expand("%"), ":~:.") : pathshorten(fnamemodify(expand("%"), ":~:."))
+  return &filetype ==# 'nerdtree' ? '' :
+        \ winwidth(0) > 70 ? fnamemodify(expand("%"), ":~:.") : pathshorten(fnamemodify(expand("%"), ":~:."))
+endfunction
+
+function! LightlineModified()
+  return &modified && &filetype !=# 'nerdtree' ? '+' : ''
+endfunction
+
+function! LightlineReadonly()
+  return &readonly && &filetype !=# 'nerdtree' ? 'RO' : ''
 endfunction
 
 function! LightlineFileformat()
@@ -80,6 +97,10 @@ endfunction
 
 function! LightlineFileencoding()
   return winwidth(0) > 70 ? &fileencoding : ''
+endfunction
+
+function! LightlineFiletype()
+  return &filetype !=# 'nerdtree' ? &filetype : ''
 endfunction
 
 " Supertab

--- a/vim/plugin_config.vim
+++ b/vim/plugin_config.vim
@@ -38,6 +38,7 @@ let NERDTreeHijackNetrw = 0
 let NERDTreeMapOpenVSplit='v'
 let NERDTreeMapOpenSplit='s'
 let NERDTreeWinSize=25
+let NERDTreeStatusline=-1
 
 " Ruby Doc
 "let g:ruby_doc_command='open'

--- a/vim/plugin_config.vim
+++ b/vim/plugin_config.vim
@@ -1,32 +1,11 @@
 " plugin_config.vim - Plugin configuration
 
-" Ack
-let g:ackprg = 'ack --nogroup --nocolor --column --with-filename'
-
 "Ag
-let g:ag_prg  = 'ag --nogroup --nocolor --column --ignore tmp'
+let g:ag_prg  = 'ag --vimgrep --smart-case'
+let g:ag_highlight=1
 
-" Command-T
-let g:CommandTMaxHeight=20
-let g:CommandTMaxFiles=20000
-let g:CommandTMaxCachedDirectories=0
-let g:CommandTCancelMap='<ESC>'
-let g:CommandTAcceptSelectionSplitMap='<C-h>' " <C-s> won't work in TERM
-
-" CtrlP
-let g:ctrlp_map = ''
-let g:ctrlp_mruf_default_order = 1
-let g:ctrlp_match_window_bottom = 1
-let g:ctrlp_match_window_reversed = 1
-let g:ctrlp_max_height = 20
-let g:ctrlp_open_new_file = 'v'
-let g:ctrlp_extensions = ['buffertag', 'tag']
-" This should be unecessary since we HAVE to set |wildignore| options
-" for Command-T (unfortunately). And these custom ignores are identical
-" to our |wildignore| settings.
-"let g:ctrlp_custom_ignore = {
-"\ 'dir':  'bin$\|db/migrate$\|log$\|public/cache$\|public/stylesheets$\|public/system$\|script$\|tmp$\|vendor$'
-"\ }
+" FZF
+let g:fzf_command_prefix = 'Fzf'
 
 " Gist
 let g:gist_post_private = 1

--- a/vim/plugin_config.vim
+++ b/vim/plugin_config.vim
@@ -140,8 +140,8 @@ let g:turbux_runner  = 'vimux'
 let g:turbux_test_type = ''
 "let g:turbux_command_prefix = 'bundle exec'
 let g:turbux_command_test_unit = 'rails test'
-let g:turbux_command_rspec = 'rspec --format documentation'
-let g:turbux_command_javascript_test = 'NODE_ENV=test mocha --exit'
+let g:turbux_command_rspec = 'bundle exec rspec --format documentation'
+let g:turbux_command_javascript_test = 'yarn'
 
 " YankStank
 let g:yankstack_map_keys = 0

--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -7,11 +7,12 @@
 " ======================================================================
 " Auto-install vim-plug
 " ======================================================================
-if empty(glob('~/.vim/autoload/plug.vim'))
-  silent !curl -fLo ~/.vim/autoload/plug.vim --create-dirs
-    \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+let data_dir = has('nvim') ? stdpath('data') . '/site' : '~/.vim'
+if empty(glob(data_dir . '/autoload/plug.vim'))
+  silent execute '!curl -fLo '.data_dir.'/autoload/plug.vim --create-dirs  https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
   autocmd VimEnter * PlugInstall --sync | source $MYVIMRC
 endif
+
 
 " ======================================================================
 " Start adding plugins
@@ -24,6 +25,7 @@ call plug#begin('~/.vim/plugins')
 " ======================================================================
 
 Plug 'itchyny/lightline.vim'
+
 
 " ======================================================================
 " Search, Buffer, Tag, and File Navigation

--- a/vim/plugins.vim
+++ b/vim/plugins.vim
@@ -31,16 +31,10 @@ Plug 'itchyny/lightline.vim'
 " Search, Buffer, Tag, and File Navigation
 " ======================================================================
 
-" Ack
-Plug 'mileszs/ack.vim'
 " Ag
 Plug 'rking/ag.vim'
 " Abolish
 Plug 'tpope/vim-abolish'
-" Command-T
-Plug 'wincent/Command-T'
-" Ctrl-P
-Plug 'kien/ctrlp.vim'
 " FZF
 Plug '/usr/local/opt/fzf' | Plug 'junegunn/fzf.vim'
 " Nerdtree
@@ -166,6 +160,8 @@ Plug 'tpope/vim-vividchalk'
 " Plugins I'm experimenting with
 " =========================================
 " ...
+" Gutentags
+" Plug 'ludovicchabant/vim-gutentags'
 
 
 " ======================================================================

--- a/vimrc
+++ b/vimrc
@@ -12,7 +12,7 @@ endif
 " Basics
 set encoding=utf-8
 set shell=/bin/bash
-set history=100 " keep 100 lines of command line history
+set history=1000 " keep lines of command line history
 set ttyfast
 set showcmd   " display incomplete commands
 set showmode  " display mode
@@ -36,6 +36,10 @@ set nowrap " do not wrap long lines
 " Escape quickly
 set ttimeout
 set ttimeoutlen=100
+
+" Max column to search for syntax.
+" This helps to avoid very slow redrawing for an XML file that is one.
+set synmaxcol=500
 
 " Folding
 set foldmethod=indent   " fold based on indent


### PR DESCRIPTION
* Updates for latest versions of vim plugins
* Disables ack, command-T, and ctrlp plugins in favor of using ag + fzf
  * adds a funky fzf+ag search